### PR TITLE
fix: improve dark mode look, and copy to clipboard functionality

### DIFF
--- a/frontend/src/components/ClaimCard.tsx
+++ b/frontend/src/components/ClaimCard.tsx
@@ -20,7 +20,7 @@ const ClaimCard = ({ claim, index }: Props) => {
   const [shared, setShared] = useState(false);
 
   const copyText = () => {
-    navigator.clipboard.writeText(claim.text);
+    navigator.clipboard.writeText(claim.explanation);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -81,7 +81,7 @@ const ClaimCard = ({ claim, index }: Props) => {
             href={s.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 rounded-full bg-brand-navy/5 border border-brand-navy/10 px-3 py-1.5 text-xs text-brand-deep font-medium hover:bg-brand-navy/10 hover:border-brand-navy/30 transition-all duration-200"
+            className="inline-flex items-center gap-1.5 rounded-full bg-brand-navy/5 border border-brand-navy/10 px-3 py-1.5 text-xs text-brand-deep dark:text-gray-200 dark:bg-white/10 dark:border-white/10 font-medium hover:bg-brand-navy/10 dark:hover:bg-white/20 hover:border-brand-navy/30 dark:hover:border-white/30 transition-all duration-200"
           >
             <span className="w-1.5 h-1.5 rounded-full bg-brand-cyan/70"></span>
             {s.domain}
@@ -95,10 +95,10 @@ const ClaimCard = ({ claim, index }: Props) => {
           <button
             onClick={copyText}
             className="inline-flex items-center gap-1.5 text-xs font-medium text-brand-muted hover:text-brand-cyan bg-transparent hover:bg-brand-cyan/10 px-2.5 py-1.5 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-brand-cyan/50"
-            aria-label="Copy claim text"
+            aria-label="Copy AI explanation"
           >
             {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-            {copied ? "Copied" : "Copy Text"}
+            {copied ? "Copied" : "Copy Explanation"}
           </button>
           <button
             onClick={shareClaim}
@@ -127,13 +127,13 @@ const ClaimCard = ({ claim, index }: Props) => {
       >
         <div className="pt-4 space-y-3">
           <div className="bg-brand-navy/5 dark:bg-white/5 rounded-xl p-4 border border-brand-navy/5 dark:border-white/5">
-            <p className="text-xs font-bold text-brand-navy uppercase tracking-wider mb-3">Grounding Metadata</p>
+            <p className="text-xs font-bold text-brand-navy dark:text-gray-200 uppercase tracking-wider mb-3">Grounding Metadata</p>
             <div className="space-y-2">
               {claim.sources.map((s, i) => (
                 <div key={i} className="group/link flex items-start gap-3 p-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/5 transition-colors">
                   <div className="mt-1 min-w-[4px] h-[4px] rounded-full bg-brand-cyan/50 group-hover/link:bg-brand-cyan transition-colors" />
                   <div>
-                    <a href={s.url} target="_blank" rel="noopener noreferrer" className="text-sm font-semibold text-brand-navy hover:text-brand-cyan hover:underline decoration-brand-cyan/30 underline-offset-4 transition-colors display-block">
+                    <a href={s.url} target="_blank" rel="noopener noreferrer" className="text-sm font-semibold text-brand-navy dark:text-gray-100 hover:text-brand-cyan dark:hover:text-brand-cyan hover:underline decoration-brand-cyan/30 underline-offset-4 transition-colors display-block">
                       {s.title}
                     </a>
                     <p className="text-xs text-brand-muted mt-0.5">{s.domain}</p>

--- a/frontend/src/components/CredibilityGauge.tsx
+++ b/frontend/src/components/CredibilityGauge.tsx
@@ -74,7 +74,7 @@ const CredibilityGauge = ({ score, verdict }: Props) => {
       </div>
 
       <div className="mt-6 text-center">
-        <h3 className="text-xl font-bold text-brand-navy mb-1">{verdict}</h3>
+        <h3 className="text-xl font-bold text-brand-navy dark:text-white mb-1">{verdict}</h3>
         <div className="h-1 w-12 rounded-full bg-gradient-to-r from-transparent via-brand-muted/30 to-transparent mx-auto" />
         <p className="text-xs font-medium text-brand-muted mt-2 uppercase tracking-wide">Credibility Rating</p>
       </div>

--- a/frontend/src/components/ImageUploadPanel.tsx
+++ b/frontend/src/components/ImageUploadPanel.tsx
@@ -83,7 +83,7 @@ const ImageUploadPanel = ({ onUpload, isLoading }: Props) => {
         )}
 
         {state === "processing" && (
-          <div className="flex flex-col items-center gap-2 text-brand-deep">
+          <div className="flex flex-col items-center gap-2 text-brand-deep dark:text-white">
             <Loader2 className="h-8 w-8 animate-spin" />
             <p className="text-sm font-medium">Running OCR...</p>
           </div>

--- a/frontend/src/components/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel.tsx
@@ -66,7 +66,7 @@ const ResultsPanel = ({ result, isLoading, onShare }: Props) => {
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
-            className="text-2xl font-bold text-brand-navy"
+            className="text-2xl font-bold text-brand-navy dark:text-white"
           >
             Analysis Results
           </motion.h2>
@@ -119,20 +119,20 @@ const ResultsPanel = ({ result, isLoading, onShare }: Props) => {
             {result.searchQueries && result.searchQueries.length > 0 && (
               <motion.div
                 variants={itemVariants}
-                className="mt-12 p-6 rounded-2xl bg-brand-navy/5 border border-brand-navy/10"
+                className="mt-12 p-6 rounded-2xl bg-brand-navy/5 dark:bg-white/5 border border-brand-navy/10 dark:border-white/10"
               >
                 <div className="flex items-center gap-2 mb-4">
                   <div className="w-2 h-2 rounded-full bg-brand-cyan animate-pulse" />
-                  <h3 className="text-lg font-semibold text-brand-navy">Gemini 3 Grounding Queries</h3>
+                  <h3 className="text-lg font-semibold text-brand-navy dark:text-white">Gemini 3 Grounding Queries</h3>
                 </div>
-                <p className="text-sm text-brand-muted mb-4">
+                <p className="text-sm text-brand-muted dark:text-neutral-400 mb-4">
                   To verify these claims, Gemini generated and executed the following Google Search queries in real-time:
                 </p>
                 <div className="flex flex-wrap gap-2">
                   {result.searchQueries.map((query, i) => (
                     <span
                       key={i}
-                      className="px-3 py-1.5 rounded-full bg-white border border-brand-navy/10 text-brand-navy text-sm font-medium shadow-sm hover:border-brand-cyan/30 transition-colors"
+                      className="px-3 py-1.5 rounded-full bg-white dark:bg-white/10 border border-brand-navy/10 dark:border-white/10 text-brand-navy dark:text-neutral-200 text-sm font-medium shadow-sm hover:border-brand-cyan/30 dark:hover:border-brand-cyan/30 transition-colors"
                     >
                       🔍 {query}
                     </span>


### PR DESCRIPTION
This pull request introduces improvements for dark mode support across multiple UI components and updates the copy functionality in `ClaimCard` to use the AI explanation instead of the claim text. The most important changes are grouped below by theme.

**Dark mode enhancements:**

* Added dark mode styles to source link buttons in `ClaimCard`, including text and background color adjustments for better visibility in dark mode.
* Updated "Grounding Metadata" section and source titles in `ClaimCard` to include dark mode text colors.
* Enhanced dark mode support for the verdict text in `CredibilityGauge`, the processing state in `ImageUploadPanel`, and the "Analysis Results" heading in `ResultsPanel`. [[1]](diffhunk://#diff-a0c4c6b06ae60421766ddb81ef357c86f8ca240c02e799b09094d0b8129dc025L77-R77) [[2]](diffhunk://#diff-34875460f18067080abf9f20d2a9edefc20f826360b16b47d54f8a9794436c72L86-R86) [[3]](diffhunk://#diff-25fd7e10ffcd5cb5235848011aa92d0238e27b34e76ac9ef7dc38a92775b1c24L69-R69)
* Improved dark mode styling for the Gemini 3 Grounding Queries section in `ResultsPanel`, including container, heading, description, and query pill styles.

**Copy functionality update:**

* Changed the copy button in `ClaimCard` to copy the AI explanation instead of the claim text, and updated button labels and aria attributes for clarity. [[1]](diffhunk://#diff-38213ef2868e0f67e1eb515d7e673b9fb22ca29cb30653dc88a9de3c8e1130a7L23-R23) [[2]](diffhunk://#diff-38213ef2868e0f67e1eb515d7e673b9fb22ca29cb30653dc88a9de3c8e1130a7L98-R101)