### PR TITLE
Remove trailing slash from Vercel URL

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
         "http://localhost:8000",
         "http://localhost:8080",
         "http://localhost",
-        "https://myverifactai.vercel.app/",
+        "https://myverifactai.vercel.app",
     ]
     
     class Config:


### PR DESCRIPTION
This pull request makes a minor update to the allowed origins in the CORS configuration by removing the trailing slash from the production frontend URL in the `Settings` class.

- Updated the `ALLOWED_ORIGINS` list in `config.py` to use `https://myverifactai.vercel.app` (without trailing slash) instead of `https://myverifactai.vercel.app/`, ensuring consistency in CORS handling.